### PR TITLE
Remove short options/flags for persistent commands in cmd/root.go.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -118,10 +118,10 @@ func init() {
 
 	rootCmd.AddCommand(mvccRootCmd, schemaRootCmd, regionRootCmd, tableRootCmd, newBase64decodeCmd, decoderCmd, newEtcdCommand())
 
-	rootCmd.PersistentFlags().IPVarP(&host, hostFlagName, "H", net.ParseIP("127.0.0.1"), "TiDB server host")
-	rootCmd.PersistentFlags().Uint16VarP(&port, portFlagName, "P", 10080, "TiDB server port")
-	rootCmd.PersistentFlags().IPVarP(&pdHost, pdHostFlagName, "i", net.ParseIP("127.0.0.1"), "PD server host")
-	rootCmd.PersistentFlags().Uint16VarP(&pdPort, pdPortFlagName, "p", 2379, "PD server port")
+	rootCmd.PersistentFlags().IPVarP(&host, hostFlagName, "", net.ParseIP("127.0.0.1"), "TiDB server host")
+	rootCmd.PersistentFlags().Uint16VarP(&port, portFlagName, "", 10080, "TiDB server port")
+	rootCmd.PersistentFlags().IPVarP(&pdHost, pdHostFlagName, "", net.ParseIP("127.0.0.1"), "PD server host")
+	rootCmd.PersistentFlags().Uint16VarP(&pdPort, pdPortFlagName, "", 2379, "PD server port")
 	rootCmd.Flags().BoolVar(&genDoc, docFlagName, false, "generate doc file")
 	if err := rootCmd.Flags().MarkHidden(docFlagName); err != nil {
 		fmt.Printf("can not mark hidden flag, flag %s is not found", docFlagName)


### PR DESCRIPTION
The addition of the global `-i` flag in commit bef868ea97970d3af1a7430c13fb5368b0fa1f2d of pr #14 conflicted with, and entirely broke, the "region" command, among others (any others that had their own `-i` flag defined).

These short options/flags for global options are unclear likely to either break subcommands or limit the flags that can be used for them later as more are added.

If you have some other proposal for how to handle this situation, that's fine. We also obviously need to add some more robust testing for tidb-ctl!

```kolbe@seastar [11:53:53] tidb-ctl $ grep -I -r '"i"' cmd/
cmd/mvcc.go:    keyCmd.Flags().Int64VarP(&mvccHID, handleFlagName, "i", 0, "get MVCC info of the key with a specified handle ID.")
cmd/mvcc.go:    idxCmd.Flags().Int64VarP(&mvccHID, handleFlagName, "i", 0, "get MVCC info of the key with a specified handle ID.")
cmd/cmdctl_test.go:     rootCmd.PersistentFlags().IPVarP(&pdHost, pdHostFlagName, "i", net.ParseIP("127.0.0.1"), "PD server host")
cmd/region.go:  regionRootCmd.Flags().Uint64VarP(&regionID, regionIDFlagName, "i", 0, "region id")
cmd/schema.go:  listTableByIDCmd.Flags().Int64VarP(&schemaTID, idFlagName, "i", 0, "get schema info of a specified table id.")
cmd/root.go:    rootCmd.PersistentFlags().IPVarP(&pdHost, pdHostFlagName, "i", net.ParseIP("127.0.0.1"), "PD server host")

kolbe@seastar [11:53:59] tidb-ctl $ ./tidb-ctl schema tid
panic: unable to redefine 'i' shorthand in "tid" flagset: it's already used for "id" flag

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).AddFlag(0xc0000b0960, 0xc0000abd60)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:823 +0x6d8
github.com/spf13/pflag.(*FlagSet).AddFlagSet.func1(0xc0000abd60)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:836 +0xaa
github.com/spf13/pflag.(*FlagSet).VisitAll(0xc0000b0f00, 0xc000101cf8)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:260 +0x94
github.com/spf13/pflag.(*FlagSet).AddFlagSet(0xc0000b0960, 0xc0000b0f00)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:834 +0x58
github.com/spf13/cobra.(*Command).mergePersistentFlags(0x1921e20)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:1387 +0x90
github.com/spf13/cobra.(*Command).InitDefaultHelpFlag(0x1921e20)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:837 +0x2f
github.com/spf13/cobra.(*Command).execute(0x1921e20, 0x195a6f0, 0x0, 0x0, 0x1921e20, 0x195a6f0)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:643 +0x57
github.com/spf13/cobra.(*Command).ExecuteC(0x19219e0, 0xa, 0x28, 0x25)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:783 +0x2ca
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:736
github.com/pingcap/tidb-ctl/cmd.Execute()
        /Users/kolbe/Devel/git/pingcap/tidb-ctl/cmd/root.go:77 +0x32
main.main()
        /Users/kolbe/Devel/git/pingcap/tidb-ctl/main.go:19 +0x20

kolbe@seastar [11:54:20] tidb-ctl $ ./tidb-ctl region
panic: unable to redefine 'i' shorthand in "region" flagset: it's already used for "rid" flag

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).AddFlag(0xc0000b45a0, 0xc0000adc20)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:823 +0x6d8
github.com/spf13/pflag.(*FlagSet).AddFlagSet.func1(0xc0000adc20)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:836 +0xaa
github.com/spf13/pflag.(*FlagSet).VisitAll(0xc0000b4c30, 0xc000119cf8)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:260 +0x94
github.com/spf13/pflag.(*FlagSet).AddFlagSet(0xc0000b45a0, 0xc0000b4c30)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:834 +0x58
github.com/spf13/cobra.(*Command).mergePersistentFlags(0x1921380)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:1387 +0x90
github.com/spf13/cobra.(*Command).InitDefaultHelpFlag(0x1921380)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:837 +0x2f
github.com/spf13/cobra.(*Command).execute(0x1921380, 0x195a6f0, 0x0, 0x0, 0x1921380, 0x195a6f0)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:643 +0x57
github.com/spf13/cobra.(*Command).ExecuteC(0x19219e0, 0xa, 0x28, 0x25)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:783 +0x2ca
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:736
github.com/pingcap/tidb-ctl/cmd.Execute()
        /Users/kolbe/Devel/git/pingcap/tidb-ctl/cmd/root.go:77 +0x32
main.main()
        /Users/kolbe/Devel/git/pingcap/tidb-ctl/main.go:19 +0x20

kolbe@seastar [11:54:55] tidb-ctl $ ./tidb-ctl mvcc index
panic: unable to redefine 'i' shorthand in "index" flagset: it's already used for "hid" flag

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).AddFlag(0xc0000a44b0, 0xc0000a1cc0)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:823 +0x6d8
github.com/spf13/pflag.(*FlagSet).AddFlagSet.func1(0xc0000a1cc0)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:836 +0xaa
github.com/spf13/pflag.(*FlagSet).VisitAll(0xc0000a4f00, 0xc0000f3cf8)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:260 +0x94
github.com/spf13/pflag.(*FlagSet).AddFlagSet(0xc0000a44b0, 0xc0000a4f00)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:834 +0x58
github.com/spf13/cobra.(*Command).mergePersistentFlags(0x1921160)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:1387 +0x90
github.com/spf13/cobra.(*Command).InitDefaultHelpFlag(0x1921160)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:837 +0x2f
github.com/spf13/cobra.(*Command).execute(0x1921160, 0x195a6f0, 0x0, 0x0, 0x1921160, 0x195a6f0)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:643 +0x57
github.com/spf13/cobra.(*Command).ExecuteC(0x19219e0, 0xa, 0x28, 0x25)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:783 +0x2ca
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:736
github.com/pingcap/tidb-ctl/cmd.Execute()
        /Users/kolbe/Devel/git/pingcap/tidb-ctl/cmd/root.go:77 +0x32
main.main()
        /Users/kolbe/Devel/git/pingcap/tidb-ctl/main.go:19 +0x20
kolbe@seastar [11:55:01] tidb-ctl $ ./tidb-ctl mvcc key
panic: unable to redefine 'i' shorthand in "key" flagset: it's already used for "hid" flag

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).AddFlag(0xc0000bc2d0, 0xc0000b5ae0)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:823 +0x6d8
github.com/spf13/pflag.(*FlagSet).AddFlagSet.func1(0xc0000b5ae0)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:836 +0xaa
github.com/spf13/pflag.(*FlagSet).VisitAll(0xc0000bcf00, 0xc00011dcf8)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:260 +0x94
github.com/spf13/pflag.(*FlagSet).AddFlagSet(0xc0000bc2d0, 0xc0000bcf00)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/pflag@v1.0.0/flag.go:834 +0x58
github.com/spf13/cobra.(*Command).mergePersistentFlags(0x1920b00)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:1387 +0x90
github.com/spf13/cobra.(*Command).InitDefaultHelpFlag(0x1920b00)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:837 +0x2f
github.com/spf13/cobra.(*Command).execute(0x1920b00, 0x195a6f0, 0x0, 0x0, 0x1920b00, 0x195a6f0)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:643 +0x57
github.com/spf13/cobra.(*Command).ExecuteC(0x19219e0, 0xa, 0x28, 0x25)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:783 +0x2ca
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/kolbe/Devel/go/pkg/mod/github.com/spf13/cobra@v0.0.1/command.go:736
github.com/pingcap/tidb-ctl/cmd.Execute()
        /Users/kolbe/Devel/git/pingcap/tidb-ctl/cmd/root.go:77 +0x32
main.main()
        /Users/kolbe/Devel/git/pingcap/tidb-ctl/main.go:19 +0x20```