### PR TITLE
add base64 decode function

### DIFF
--- a/cmd/decoder.go
+++ b/cmd/decoder.go
@@ -210,11 +210,25 @@ func decodeKeyFunc(c *cobra.Command, args []string) error {
 		}
 		return nil
 	}
-	// Try to decode using index_value format.
+	// Try to decode base64 format key.
 	b64decode, err := base64.StdEncoding.DecodeString(keyValue)
 	if err != nil {
 		return err
 	}
+	tableID, rowID, err = decodeTableRow(b64decode)
+	if err == nil {
+		c.Printf("format: table_row\ntable_id: %v\nrow_id: %v\n", tableID, rowID)
+		return nil
+	}
+	tableID, rowID, indexvalues, err = decodeTableIndex(b64decode)
+	if err == nil {
+		c.Printf("format: table_index\ntable_id: %v\nindex_id: %v\n", tableID, rowID)
+		for i, iv := range indexvalues {
+			c.Printf("index_value[%v]: {type: %v, value: %v}\n", i, iv.typename, iv.valueStr)
+		}
+		return nil
+	}
+	// Try to decode base64 format index_value.
 	indexvalues, err = decodeIndexValue(b64decode)
 	if err != nil {
 		return err

--- a/cmd/decoder_test.go
+++ b/cmd/decoder_test.go
@@ -61,7 +61,7 @@ func (s *decoderTestSuite) TestTableIndexDecode(c *C) {
 		"index_value[2]: {type: bigint, value: 20190616}\n")
 }
 
-func (s *decoderTestSuite) TestIndexValueDecode(c *C) {
+func (s *decoderTestSuite) TestBase64Decode(c *C) {
 	cmd := initCommand()
 	args := []string{"decoder", "CAQCBmFiYw=="}
 	_, output, err := executeCommandC(cmd, args...)
@@ -69,4 +69,10 @@ func (s *decoderTestSuite) TestIndexValueDecode(c *C) {
 	c.Check(string(output), Equals, "format: index_value\n"+
 		"index_value[0]: {type: bigint, value: 2}\n"+
 		"index_value[1]: {type: bytes, value: abc}\n")
+	args = []string{"decoder", "dIAAAAAAAABAX3KAAAAAAAAAAQ=="}
+	_, output, err = executeCommandC(cmd, args...)
+	c.Assert(err, IsNil)
+	c.Check(string(output), Equals, "format: table_row\n"+
+		"table_id: 64\n"+
+		"row_id: 1\n")
 }


### PR DESCRIPTION
tidb-contral currently only support decode base64 index value. But there is some key encoded with base64:

`[2pc.go:613] ["key already exists"] [conn=1] [key="dIAAAAAAAABAX3KAAAAAAAAAAQ=="] `