### PR TITLE
cmd: fix table by id command URL

### DIFF
--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -23,7 +23,7 @@ import (
 const (
 	schemaRoot       = "schema"
 	schemaRootPrefix = schemaRoot + "/"
-	tableIDPrefix    = schemaRootPrefix + "?table_id="
+	tableIDPrefix    = schemaRoot + "?table_id="
 )
 
 // schema command flags


### PR DESCRIPTION
Tiny fix for https://asktug.com/t/topic/64123

```
./tidb-ctl schema tid -i 5 
404 page not found
```

The URL is wrong, it visits `schema/?table_id=5` which should be `schema?table_id=5`.

@jackysp 